### PR TITLE
Bump tasty bound

### DIFF
--- a/indents.cabal
+++ b/indents.cabal
@@ -45,7 +45,7 @@ Test-suite indents-tests
 
   Build-depends:
     indents,
-    tasty       >= 0.11 && < 0.13,
+    tasty       >= 0.11 && < 1.1,
     tasty-hunit >= 0.9  && < 0.11,
     -- Copy-pasted from 'Library' dependencies.
     base   >= 4 && < 5,


### PR DESCRIPTION
I've verified that the tests pass when using `tasty-1.0.1.1`.