### PR TITLE
bumping tasty to 1.2.3

### DIFF
--- a/indents.cabal
+++ b/indents.cabal
@@ -47,7 +47,7 @@ Test-suite indents-tests
 
   Build-depends:
     indents,
-    tasty       >= 0.11 && < 1.1,
+    tasty       >= 0.11 && < 1.2.4,
     tasty-hunit >= 0.9  && < 0.11,
     -- Copy-pasted from 'Library' dependencies.
     base   >= 4 && < 5,


### PR DESCRIPTION
stack.yaml should probably also be updated, but I just did the minimum necessary to get this to build with nix.